### PR TITLE
Add CooldownBar

### DIFF
--- a/player/Player.gd
+++ b/player/Player.gd
@@ -51,6 +51,8 @@ func shoot(vel: Vector2):
 		can_shoot = false
 		$ShootLine.region_rect.position.y = 16.0
 		$Shoot/Timer.start()
+		$CooldownBar/AnimationPlayer.playback_speed = 1.0 / $Shoot/Timer.wait_time
+		$CooldownBar/AnimationPlayer.play("charge")
 		$Shoot.play()
 		emit_signal("shoot", global_position, vel, bullet)
 		velocity -= vel

--- a/player/Player.tscn
+++ b/player/Player.tscn
@@ -1,10 +1,12 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=16 format=2]
 
 [ext_resource path="res://player/player.png" type="Texture" id=1]
 [ext_resource path="res://player/Player.gd" type="Script" id=2]
 [ext_resource path="res://world/light.png" type="Texture" id=3]
+[ext_resource path="res://player/cooldown_bar/recharging_flat_box.tres" type="StyleBox" id=4]
 [ext_resource path="res://player/cannon.wav" type="AudioStream" id=5]
 [ext_resource path="res://player/hurt.wav" type="AudioStream" id=6]
+[ext_resource path="res://player/cooldown_bar/background_flat_box.tres" type="StyleBox" id=7]
 
 [sub_resource type="CanvasItemMaterial" id=1]
 light_mode = 1
@@ -104,6 +106,33 @@ tracks/0/keys = {
 "values": [ true, false ]
 }
 
+[sub_resource type="Animation" id=8]
+resource_name = "charge"
+tracks/0/type = "value"
+tracks/0/path = NodePath(".:value")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0, 1 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 0,
+"values": [ 0.0, 100.0 ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath(".:visible")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 1 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ true, false ]
+}
+
 [node name="Player" type="KinematicBody2D"]
 collision_layer = 2
 script = ExtResource( 2 )
@@ -185,6 +214,24 @@ autostart = true
 
 [node name="Immune" type="AnimationPlayer" parent="."]
 anims/immune = SubResource( 7 )
+
+[node name="CooldownBar" type="ProgressBar" parent="."]
+visible = false
+margin_left = -32.0
+margin_top = 7.0
+margin_right = 32.0
+margin_bottom = 15.0
+custom_styles/fg = ExtResource( 4 )
+custom_styles/bg = ExtResource( 7 )
+max_value = 100.0
+value = 100.0
+percent_visible = false
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="CooldownBar"]
+anims/charge = SubResource( 8 )
 [connection signal="timeout" from="Shoot/Timer" to="." method="_on_Timer_timeout"]
 [connection signal="area_entered" from="HitBox" to="." method="_on_HitBox_area_entered"]
 [connection signal="body_entered" from="HitBox" to="." method="_on_HitBox_area_entered"]

--- a/player/cooldown_bar/background_flat_box.tres
+++ b/player/cooldown_bar/background_flat_box.tres
@@ -1,0 +1,10 @@
+[gd_resource type="StyleBoxFlat" format=2]
+
+[resource]
+bg_color = Color( 0.188235, 0.105882, 0.0588235, 1 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 1, 1, 1, 1 )
+anti_aliasing = false

--- a/player/cooldown_bar/recharging_flat_box.tres
+++ b/player/cooldown_bar/recharging_flat_box.tres
@@ -1,0 +1,10 @@
+[gd_resource type="StyleBoxFlat" format=2]
+
+[resource]
+bg_color = Color( 0.666667, 0.333333, 0.12549, 1 )
+border_width_left = 1
+border_width_top = 1
+border_width_right = 1
+border_width_bottom = 1
+border_color = Color( 1, 1, 1, 1 )
+anti_aliasing = false


### PR DESCRIPTION
I think it could be a nice improvement to have a ProgressBar that adds a visualization of the time remaining for the weapon to cooldown so I've added a progress bar below the player's ship for that.

![lighthouse-keeper-cooldown-bar](https://user-images.githubusercontent.com/10171059/83420633-4d783b80-a3fd-11ea-9fc0-196a49c073bb.gif)

The CooldownBar syncs with the `$Shoot/Timer.wait_time` so if you want to add power-ups that decrease the cooldown or debuffs that increase it you don't have to be concerned with the CooldownBar :smile: 

I hope you find it useful! No problem if you want to reject the PR.